### PR TITLE
Add new option allowSingleTapDaySelection

### DIFF
--- a/lib/src/controllers.dart
+++ b/lib/src/controllers.dart
@@ -14,7 +14,8 @@ class RangePickerController {
       this.endDate,
       this.minimumDateRangeLength,
       this.maximumDateRangeLength,
-      this.disabledDates = const []}) {
+      this.disabledDates = const [],
+      this.allowSingleTapDaySelection = false}) {
     if (dateRange != null) {
       startDate = dateRange.start;
       endDate = dateRange.end;
@@ -25,6 +26,8 @@ class RangePickerController {
   int? minimumDateRangeLength;
 
   List<DateTime> disabledDates;
+
+  final bool allowSingleTapDaySelection;
 
   final ValueChanged<DateRange?> onDateRangeChanged;
 
@@ -70,6 +73,9 @@ class RangePickerController {
     } else {
       startDate = date;
       endDate = null;
+      if (allowSingleTapDaySelection) {
+        onDateRangeChanged(DateRange(startDate!, startDate!));
+      }
     }
   }
 

--- a/lib/src/widgets/date_range_picker.dart
+++ b/lib/src/widgets/date_range_picker.dart
@@ -139,6 +139,7 @@ class DateRangePickerWidget extends StatefulWidget {
     this.height = 329,
     this.displayMonthsSeparator = true,
     this.separatorThickness = 1,
+    this.allowSingleTapDaySelection = false,
   }) : super(key: key);
 
   /// Called whenever the selected date range is changed.
@@ -174,6 +175,11 @@ class DateRangePickerWidget extends StatefulWidget {
   /// A list of dates that are disabled and cannot be selected.
   final List<DateTime> disabledDates;
 
+  /// Set [allowSingleTapDaySelection] to true to allow single day selection
+  /// with just one click (to avoid the user being required to tap on the same
+  /// day twice).
+  final bool allowSingleTapDaySelection;
+
   /// The theme used to customize the appearance of the picker.
   final CalendarTheme theme;
 
@@ -196,6 +202,7 @@ class DateRangePickerWidgetState extends State<DateRangePickerWidget> {
     disabledDates: widget.disabledDates,
     minimumDateRangeLength: widget.minimumDateRangeLength,
     maximumDateRangeLength: widget.maximumDateRangeLength,
+    allowSingleTapDaySelection: widget.allowSingleTapDaySelection,
   );
 
   late final calendarController = CalendarWidgetController(


### PR DESCRIPTION
If the user wants to select a single-day range they need to tap twice (at least, if the initial date range is not null). 
Setting to `true` the new `allowSingleTapDaySelection` option will instead call onDateChanged even at the first tap.

The default value is `false` for backward compatibility.
