### PR TITLE
Allow customization of quick ranges background color

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -231,5 +231,20 @@ class _MyHomePageState extends State<MyHomePage> {
         initialDisplayedDate:
             selectedDateRange?.start ?? DateTime(2023, 11, 20),
         onDateRangeChanged: onDateRangeChanged,
+        height: 350,
+        theme: const CalendarTheme(
+          selectedColor: Colors.blue,
+          dayNameTextStyle: TextStyle(color: Colors.black45, fontSize: 10),
+          inRangeColor: Color(0xFFD9EDFA),
+          inRangeTextStyle: TextStyle(color: Colors.blue),
+          selectedTextStyle: TextStyle(color: Colors.white),
+          todayTextStyle: TextStyle(fontWeight: FontWeight.bold),
+          defaultTextStyle: TextStyle(color: Colors.black, fontSize: 12),
+          radius: 10,
+          tileSize: 40,
+          disabledTextStyle: TextStyle(color: Colors.grey),
+          quickDateRangeBackgroundColor: Color(0xFFDAEDF7),
+          selectedQuickDateRangeColor: Colors.blue,
+        ),
       );
 }

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -123,6 +123,9 @@ class CalendarTheme {
   /// The color of the selected quick selection dateRange (left border).
   final Color? selectedQuickDateRangeColor;
 
+  /// The background color of the sidebar holding quick selections
+  final Color? quickDateRangeBackgroundColor;
+
   /// The color of the vertical separator between months
   final Color? separatorColor;
 
@@ -138,6 +141,7 @@ class CalendarTheme {
         color: Colors.black,
         fontSize: 14,
       ),
+      this.quickDateRangeBackgroundColor,
       this.monthTextStyle,
       this.dayNameTextStyle =
           const TextStyle(color: Colors.black45, fontSize: 10),

--- a/lib/src/widgets/date_range_picker.dart
+++ b/lib/src/widgets/date_range_picker.dart
@@ -274,8 +274,10 @@ class DateRangePickerWidgetState extends State<DateRangePickerWidget> {
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
-          SizedBox(
+          Container(
             width: 200,
+            color: widget.theme.quickDateRangeBackgroundColor,
+            padding: const EdgeInsets.only(right: 16),
             child: QuickSelectorWidget(
               selectedDateRange: controller.dateRange,
               quickDateRanges: widget.quickDateRanges,
@@ -289,7 +291,7 @@ class DateRangePickerWidgetState extends State<DateRangePickerWidget> {
             color: Colors.black12,
             width: 1,
             height: double.infinity,
-            margin: const EdgeInsets.symmetric(horizontal: 16),
+            margin: const EdgeInsets.only(right: 16),
           ),
           child,
           if (widget.quickDateRanges.isNotEmpty)


### PR DESCRIPTION
Add option to change the background color of the side panel holding quick ranges.

```dart
      DateRangePickerWidget(
        // ...
        theme: const CalendarTheme(
          // ...
          quickDateRangeBackgroundColor: Color(0xFFDAEDF7),
          selectedQuickDateRangeColor: Colors.blue,
        ),
      );
```

![image](https://github.com/GaspardMerten/date_range_picker/assets/4000539/90ce58ff-94e1-4f50-91e7-858fb92f3abe)
