### PR TITLE
Mobile quick ranges

### DIFF
--- a/lib/src/controllers.dart
+++ b/lib/src/controllers.dart
@@ -15,7 +15,9 @@ class RangePickerController {
       this.minimumDateRangeLength,
       this.maximumDateRangeLength,
       this.disabledDates = const [],
-      this.allowSingleTapDaySelection = false}) {
+      this.allowSingleTapDaySelection = false,
+      this.allowBackwardsDaySelection = true})
+      : origMinDate = minDate {
     if (dateRange != null) {
       startDate = dateRange.start;
       endDate = dateRange.end;
@@ -29,10 +31,15 @@ class RangePickerController {
 
   final bool allowSingleTapDaySelection;
 
+  /// Whether the user can select a date range backwards (i.e. start date is after end date).
+  final bool allowBackwardsDaySelection;
+
   final ValueChanged<DateRange?> onDateRangeChanged;
 
   /// The minimum date that can be selected. (inclusive)
   DateTime? minDate;
+
+  final DateTime? origMinDate;
 
   /// The maximum date that can be selected. (inclusive)
   DateTime? maxDate;
@@ -83,6 +90,9 @@ class RangePickerController {
       if (allowSingleTapDaySelection) {
         onDateRangeChanged(DateRange(startDate!, startDate!));
       }
+    }
+    if (!allowBackwardsDaySelection) {
+      minDate = startDate != null && endDate == null ? startDate : origMinDate;
     }
   }
 

--- a/lib/src/controllers.dart
+++ b/lib/src/controllers.dart
@@ -70,7 +70,8 @@ class RangePickerController {
   void onDateChanged(DateTime date) {
     if (startDate == null) {
       startDate = date;
-      onDateRangeChanged(DateRange(startDate!, startDate!));
+      if (maximumDateRangeLength == 1) endDate = date;
+      onDateRangeChanged(DateRange(startDate!, endDate ?? startDate!));
     } else if (endDate == null) {
       if (date == startDate) {
         endDate = date;
@@ -86,9 +87,9 @@ class RangePickerController {
       }
     } else {
       startDate = date;
-      endDate = null;
+      endDate = maximumDateRangeLength == 1 ? startDate : null;
       if (allowSingleTapDaySelection) {
-        onDateRangeChanged(DateRange(startDate!, startDate!));
+        onDateRangeChanged(DateRange(startDate!, endDate ?? startDate!));
       }
     }
     if (!allowBackwardsDaySelection) {

--- a/lib/src/widgets/date_range_picker.dart
+++ b/lib/src/widgets/date_range_picker.dart
@@ -151,6 +151,7 @@ class DateRangePickerWidget extends StatefulWidget {
     this.displayMonthsSeparator = true,
     this.separatorThickness = 1,
     this.allowSingleTapDaySelection = false,
+    this.allowBackwardsDaySelection = true,
     this.firstDayOfWeek = 0,
     this.lengthOfDateName = 3,
   })  : assert(
@@ -197,6 +198,10 @@ class DateRangePickerWidget extends StatefulWidget {
   /// day twice).
   final bool allowSingleTapDaySelection;
 
+  /// Set [allowBackwardsDaySelection] to false to prevent the user from selecting
+  /// a date range backwards (i.e. start date is after end date).
+  final bool allowBackwardsDaySelection;
+
   /// The theme used to customize the appearance of the picker.
   final CalendarTheme theme;
 
@@ -226,6 +231,7 @@ class DateRangePickerWidgetState extends State<DateRangePickerWidget> {
     minimumDateRangeLength: widget.minimumDateRangeLength,
     maximumDateRangeLength: widget.maximumDateRangeLength,
     allowSingleTapDaySelection: widget.allowSingleTapDaySelection,
+    allowBackwardsDaySelection: widget.allowBackwardsDaySelection,
   );
 
   late final calendarController = CalendarWidgetController(


### PR DESCRIPTION
Show quick ranges as dropdown on mobile.

New properties added:
* `mobileLayoutBreakpoint` (defaults to 550px): se the mobile breakpoint to activate the responsive layout
* `quickDateRangesDropdownLabel` (defaults to "Select a range"): the label for the dropdown

<img width="637" height="834" alt="image" src="https://github.com/user-attachments/assets/ac051fab-57bb-40ca-b3a8-e499bba9e9bc" />

<img width="408" height="604" alt="image" src="https://github.com/user-attachments/assets/d6fc3277-943f-46fd-be75-2417f20fc494" />
